### PR TITLE
Fix resource bundle path

### DIFF
--- a/NIMKit/NIMKit/Classes/Category/UIImage+NIMKit.m
+++ b/NIMKit/NIMKit/Classes/Category/UIImage+NIMKit.m
@@ -94,32 +94,12 @@
 
 
 + (UIImage *)nim_imageInKit:(NSString *)imageName{
-    NSString *bundleName = [[NIMKit sharedKit] resourceBundleName];
-    NSURL *bundleURL = [[NSBundle bundleForClass:[NIMKit class]] URLForResource:bundleName withExtension:nil];
-    
-    if (!bundleURL) // 兼容Pod use_frameworks!下，用户自定义资源文件
-    {
-        bundleURL = [[NSBundle mainBundle] URLForResource:bundleName withExtension:nil];
-    }
-    
-    if (!bundleURL)
-    {
-        return nil;
-    }
-
-    NSBundle *resourceBundle = [NSBundle bundleWithURL:bundleURL];
-    UIImage *image = [UIImage imageNamed:imageName inBundle:resourceBundle compatibleWithTraitCollection:nil];
-    
-    NSString *name = [bundleName stringByAppendingPathComponent:imageName];
-    //优先取上层bundle 里的图片，如果没有，则用自带资源的图片
-    return image? image : [UIImage imageNamed:name];
+    return [UIImage imageNamed:imageName inBundle:[NIMKit sharedKit].resourceBundle compatibleWithTraitCollection:nil];
 }
 
 + (UIImage *)nim_emoticonInKit:(NSString *)imageName
 {
-    NSString *name = [[[NIMKit sharedKit] emoticonBundleName] stringByAppendingPathComponent:imageName];
-    UIImage *image = [UIImage imageNamed:name];
-    return image;
+    return [UIImage imageNamed:imageName inBundle:[NIMKit sharedKit].emoticonBundle compatibleWithTraitCollection:nil];
 }
 
 - (UIImage *)nim_imageForAvatarUpload

--- a/NIMKit/NIMKit/Classes/Global/NIMKitProgressHUD.m
+++ b/NIMKit/NIMKit/Classes/Global/NIMKitProgressHUD.m
@@ -9,6 +9,7 @@
 #import "NIMKitProgressHUD.h"
 #import "UIView+NIM.h"
 #import "NIMKit.h"
+#import "UIImage+NIMKit.h"
 
 @interface NIMKitProgressHUD()
 
@@ -91,24 +92,7 @@
         
         CALayer *maskLayer = [CALayer layer];
         
-        NSString *bundleName = [[NIMKit sharedKit] resourceBundleName];
-        NSURL *bundleURL = [[NSBundle bundleForClass:[NIMKitProgressHUD class]] URLForResource:bundleName withExtension:nil];
-        
-        if (!bundleURL) // 兼容Pod use_frameworks!下，用户自定义资源文件
-        {
-            bundleURL = [[NSBundle mainBundle] URLForResource:bundleName withExtension:nil];
-        }
-        
-        if (bundleURL)
-        {
-            NSBundle *imageBundle = [NSBundle bundleWithURL:bundleURL];
-            
-            if (imageBundle)
-            {
-                NSString *path = [imageBundle pathForResource:@"bk_angle_mask" ofType:@"png"];
-                maskLayer.contents = (__bridge id)[[UIImage imageWithContentsOfFile:path] CGImage];
-            }
-        }
+        maskLayer.contents = (__bridge id)[[UIImage nim_imageInKit:@"bk_angle_mask"] CGImage];
         
         maskLayer.frame = _indefiniteAnimatedLayer.bounds;
         _indefiniteAnimatedLayer.mask = maskLayer;

--- a/NIMKit/NIMKit/Classes/NIMKit.h
+++ b/NIMKit/NIMKit/Classes/NIMKit.h
@@ -97,14 +97,14 @@ FOUNDATION_EXPORT const unsigned char NIMKitVersionString[];
 
 
 /**
- *  NIMKit图片资源所在的 bundle 名称。
+ *  NIMKit图片资源所在的 bundle 。
  */
-@property (nonatomic,copy)      NSString *resourceBundleName;
+@property (nonatomic,copy)      NSBundle *resourceBundle;
 
 /**
- *  NIMKit表情资源所在的 bundle 名称。
+ *  NIMKit表情资源所在的 bundle 。
  */
-@property (nonatomic,copy)      NSString *emoticonBundleName;
+@property (nonatomic,copy)      NSBundle *emoticonBundle;
 
 
 /**

--- a/NIMKit/NIMKit/Classes/NIMKit.m
+++ b/NIMKit/NIMKit/Classes/NIMKit.m
@@ -29,8 +29,8 @@ extern NSString *const NIMKitTeamInfoHasUpdatedNotification;
 - (instancetype)init
 {
     if (self = [super init]) {
-        _resourceBundleName  = @"NIMKitResource.bundle";
-        _emoticonBundleName  = @"NIMKitEmoticon.bundle";
+        _resourceBundle  = [self bundleForName:@"NIMKitResource"];
+        _emoticonBundle  = [self bundleForName:@"NIMKitEmoticon"];
         
         _firer = [[NIMKitNotificationFirer alloc] init];
         _provider = [[NIMKitDataProviderImpl alloc] init];   //默认使用 NIMKit 的实现
@@ -40,6 +40,13 @@ extern NSString *const NIMKitTeamInfoHasUpdatedNotification;
         [self preloadNIMKitBundleResource];
     }
     return self;
+}
+
+- (NSBundle *)bundleForName:(NSString *)name
+{
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSURL *url = [bundle URLForResource:name withExtension:@"bundle"];
+    return url ? [NSBundle bundleWithURL:url] : nil;
 }
 
 + (instancetype)sharedKit

--- a/NIMKit/NIMKit/Classes/NIMKit.m
+++ b/NIMKit/NIMKit/Classes/NIMKit.m
@@ -44,7 +44,7 @@ extern NSString *const NIMKitTeamInfoHasUpdatedNotification;
 
 - (NSBundle *)bundleForName:(NSString *)name
 {
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *bundle = [NSBundle bundleForClass:[NIMKit class]];
     NSURL *url = [bundle URLForResource:name withExtension:@"bundle"];
     return url ? [NSBundle bundleWithURL:url] : nil;
 }

--- a/NIMKit/NIMKit/Classes/Sections/Input/NIMInputEmoticonManager.m
+++ b/NIMKit/NIMKit/Classes/Sections/Input/NIMInputEmoticonManager.m
@@ -150,9 +150,7 @@
 {
     NSMutableArray *catalogs = [NSMutableArray array];
     
-    NSURL *url = [[NSBundle bundleForClass:[self class]] URLForResource:[[NIMKit sharedKit] emoticonBundleName]
-                                         withExtension:nil];
-    NSBundle *bundle = [NSBundle bundleWithURL:url];
+    NSBundle *bundle = [NIMKit sharedKit].emoticonBundle;
     
     NSString *filepath = [bundle pathForResource:@"emoji_ios" ofType:@"plist" inDirectory:NIMKit_EmojiPath];
     if (filepath) {


### PR DESCRIPTION
发现一个 bug ：部分 Emoji 图片未加载成功，在表情面板不显示，在消息里显示为 [?]

![WX20190824-002353](https://user-images.githubusercontent.com/526008/63612560-188abd00-c611-11e9-8ac0-67aa44c59b23.png)

经查是因为 NIMKit 是以动态库方法集成的，而 `+[UIImage nim_emoticonInKit:]` 没有使用使用正确的表情 bundle 路径，导致图片类的表情加载失败。

---

修复：
- 使用 `bundleForClass` 获取资源 bundle 的路径，兼容静态库和动态库集成
- 修改 NIMKit 的 resourceBundleName 和 emoticonBundleName 类型为 `NSBundle` ，以避免其他地方直接使用 bundle name 来拼接路径造成资源无法加载。同时作为 NIMKit 的属性，也缓存了这两个 bundle 对象，提升加载资源文件的效率。